### PR TITLE
Image loader compatability

### DIFF
--- a/mlops/data/transforms/LoadImageXNATd.py
+++ b/mlops/data/transforms/LoadImageXNATd.py
@@ -76,7 +76,7 @@ class LoadImageXNATd(MapTransform):
                             # image loader needs full path to load single images
                             logger.info(f"Downloading images: {images_path}")
                             if len(images_path) == 1:
-                                image, meta = self.image_loader(images_path)
+                                image = self.image_loader(images_path)
 
                             # image loader needs directory path to load 3D images
                             else:
@@ -84,10 +84,12 @@ class LoadImageXNATd(MapTransform):
                                 image_dirs = list(set(os.path.dirname(image_path) for image_path in images_path))
                                 if len(image_dirs) > 1:
                                     raise ValueError(f'More than one image series found in {images_path}')
-                                image, meta = self.image_loader(image_dirs[0])
+                                image = self.image_loader(image_dirs[0])
 
                             d[data_label] = image
                             if self.return_meta:
                                 d[data_label + '_meta'] = meta
+
+
 
         return d

--- a/mlops/data/transforms/LoadImageXNATd.py
+++ b/mlops/data/transforms/LoadImageXNATd.py
@@ -17,13 +17,12 @@ class LoadImageXNATd(MapTransform):
     """
 
     def __init__(self, keys: KeysCollection,  xnat_configuration: dict = None,
-                 image_loader: Transform = LoadImage(), validate_data: bool = False, expected_filetype_ext: str = '.dcm', return_meta=False):
+                 image_loader: Transform = LoadImage(), validate_data: bool = False, expected_filetype_ext: str = '.dcm'):
         super().__init__(keys)
         self.image_loader = image_loader
         self.xnat_configuration = xnat_configuration
         self.expected_filetype = expected_filetype_ext
         self.validate_data = validate_data
-        self.return_meta = return_meta
 
     def __call__(self, data):
         """
@@ -87,9 +86,5 @@ class LoadImageXNATd(MapTransform):
                                 image = self.image_loader(image_dirs[0])
 
                             d[data_label] = image
-                            if self.return_meta:
-                                d[data_label + '_meta'] = meta
-
-
 
         return d


### PR DESCRIPTION
removes the additional metadata from LoadImageXNATd

the metadata is still available within the metatensor "image" object,but this means the function is compatible with more image_loader kwargs (i.e. image_only)