### PR TITLE
Update minio

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ POSTGRES_DB=db
  docker-compose up -d --build
  ```
 
+4. To enable access to the minio artifact storage the host machine needs to be authenticated. Any of the methods supported by boto3 should be compatible, the recommended authentication method is to create an [aws credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html). e.g. for ubuntu/linux
+
+```
+[credentials]
+AWS_ACCESS_KEY_ID=minioUsername
+AWS_SECRET_ACCESS_KEY=minioPassword
+```
+
 Upon a successful build the server should now be up and running locally. By default, the mlflow user interface can be accessed at ```http:/localhost:85``` and minio can be accessed at ```https:/localhost:8002```.
 
 To check if the server is up and running successfully running ```docker ps``` in the terminal lists the running containers, and we should see something like:

--- a/mlflow_server/docker-compose.yml
+++ b/mlflow_server/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.8'
 
 services:
     nginx:
@@ -9,6 +9,7 @@ services:
         ports:
             - "85:85"
             - "8002:8002"
+            - "8003:8003"
         networks:
             - frontend
         depends_on:
@@ -16,25 +17,44 @@ services:
 
     minio:
         restart: always
-        image: minio/minio:RELEASE.2021-03-17T02-33-02Z
+        image: minio/minio:RELEASE.2022-11-08T05-27-07Z.fips
         container_name: mlflow_s3
         expose:
             - "9000"
-        command: server /data
+            - "9001"
+        command: server /data --console-address ":9001"
         networks:
             - frontend
             - backend
+        healthcheck:
+            test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
+            interval: 30s
+            timeout: 20s
+            retries: 3
         environment:
             - MINIO_ROOT_USER=${AWS_ACCESS_KEY_ID}
             - MINIO_ROOT_PASSWORD=${AWS_SECRET_ACCESS_KEY}
-            - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-            - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+#            - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+#            - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 #        volumes:
 #            - minio_data:/data
         volumes:
             - type: bind
-              source: ~/MLOps_data/mlflow_minio
+              source: ~/MLOps_data/mlflow_minio_migrate
               target: /data
+
+    createbuckets:
+        image: minio/mc
+        depends_on:
+            - minio
+        networks:
+            - backend
+        entrypoint: >
+            /bin/sh -c "
+            /usr/bin/mc alias set myminio http://minio:9000 ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY};
+            /usr/bin/mc mb myminio/mlflow;
+            /usr/bin/mc policy set public myminio/mlflow;
+            exit 0;"
 
     db:
         image: postgres:13.1
@@ -53,7 +73,7 @@ services:
             - type: bind
               source: ~/MLOps_data/mlflow_db
               target: /var/lib/postgresql/data
-
+#
     web:
         restart: always
         build: ./mlflow
@@ -76,9 +96,9 @@ services:
         command: mlflow server --backend-store-uri postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB} --default-artifact-root s3://mlflow/ --host 0.0.0.0
 
 # use these docker volumes for testings and development - use bind mounts in production
-#volumes:
-#    dbdata_pg:
-#    minio_data:
+volumes:
+    dbdata_pg:
+    minio_data:
 
 networks:
     frontend:

--- a/mlflow_server/docker-compose.yml
+++ b/mlflow_server/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
     minio:
         restart: always
-        image: minio/minio:RELEASE.2022-11-08T05-27-07Z.fips
+        image: minio/minio:RELEASE.2022-11-08T05-27-07Z
         container_name: mlflow_s3
         expose:
             - "9000"

--- a/mlflow_server/docker-compose.yml
+++ b/mlflow_server/docker-compose.yml
@@ -34,13 +34,11 @@ services:
         environment:
             - MINIO_ROOT_USER=${AWS_ACCESS_KEY_ID}
             - MINIO_ROOT_PASSWORD=${AWS_SECRET_ACCESS_KEY}
-#            - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-#            - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 #        volumes:
 #            - minio_data:/data
         volumes:
             - type: bind
-              source: ~/MLOps_data/mlflow_minio_migrate
+              source: ~/MLOps_data/mlflow_minio
               target: /data
 
     createbuckets:
@@ -73,7 +71,7 @@ services:
             - type: bind
               source: ~/MLOps_data/mlflow_db
               target: /var/lib/postgresql/data
-#
+
     web:
         restart: always
         build: ./mlflow
@@ -96,9 +94,9 @@ services:
         command: mlflow server --backend-store-uri postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB} --default-artifact-root s3://mlflow/ --host 0.0.0.0
 
 # use these docker volumes for testings and development - use bind mounts in production
-volumes:
-    dbdata_pg:
-    minio_data:
+#volumes:
+#    dbdata_pg:
+#    minio_data:
 
 networks:
     frontend:

--- a/mlflow_server/nginx/minio.conf
+++ b/mlflow_server/nginx/minio.conf
@@ -1,14 +1,16 @@
 server {
-    # frontend port
     listen       8002;
+    listen  [::]:8002;
+    server_name  localhost;
 
-     # To allow special characters in headers
-     ignore_invalid_headers off;
-     # Allow any size file to be uploaded.
-     # Set to a value such as 1000m; to restrict file size to a specific value
-     client_max_body_size 0;
-     # To disable buffering
-     proxy_buffering off;
+    # To allow special characters in headers
+    ignore_invalid_headers off;
+    # Allow any size file to be uploaded.
+    # Set to a value such as 1000m; to restrict file size to a specific value
+    client_max_body_size 0;
+    # To disable buffering
+    proxy_buffering off;
+    proxy_request_buffering off;
 
     location / {
         proxy_set_header Host $http_host;
@@ -23,5 +25,42 @@ server {
         chunked_transfer_encoding off;
 
         proxy_pass http://minio:9000;
+    }
+}
+
+server {
+    listen       8003;
+    listen  [::]:8003;
+    server_name  localhost;
+
+    # To allow special characters in headers
+    ignore_invalid_headers off;
+    # Allow any size file to be uploaded.
+    # Set to a value such as 1000m; to restrict file size to a specific value
+    client_max_body_size 0;
+    # To disable buffering
+    proxy_buffering off;
+    proxy_request_buffering off;
+
+    location / {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-NginX-Proxy true;
+
+        # This is necessary to pass the correct IP to be hashed
+        real_ip_header X-Real-IP;
+
+        proxy_connect_timeout 300;
+
+        # To support websocket
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        chunked_transfer_encoding off;
+
+        proxy_pass http://minio:9001;
     }
 }

--- a/mlops/Experiment.py
+++ b/mlops/Experiment.py
@@ -185,7 +185,7 @@ class Experiment:
         """
 
         # Build dockerfile into an MAP image
-        docker_build_cmd = f'''docker build -f "{path}" -t {self.experiment_name} "{self.project_path}"'''
+        docker_build_cmd = f'''docker build -t {self.experiment_name} "{path}"'''
         if sys.platform != "win32":
             docker_build_cmd += """ --build-arg UID=$(id -u) --build-arg GID=$(id -g)"""
         if no_cache:

--- a/mlops/Experiment.py
+++ b/mlops/Experiment.py
@@ -42,7 +42,7 @@ class Experiment:
         else:
             self.check_dirty()
 
-        self.check_environment_variables()
+        # self.check_environment_variables()
         self.config_setup()
         self.use_gpu = self.config.getboolean('system', 'USE_GPU')
         self.env_setup()
@@ -133,7 +133,7 @@ class Experiment:
         logger.info('Setting experiment to: {0} '.format(self.experiment_name))
         mlflow.set_experiment(self.experiment_name)
 
-        self.configure_minio()
+        # self.configure_minio()
         self.experiment_id = exp_id
 
     def print_experiment_info(self):

--- a/mlops/utils/logger.py
+++ b/mlops/utils/logger.py
@@ -3,9 +3,11 @@ import colorlog
 import sys
 import time
 import os
+from pathlib import Path
+home = str(Path.home())
 
-os.makedirs('LOGS', exist_ok=True)
-LOG_FILE: str = os.path.join('LOGS', f'{time.strftime("%Y%m%d-%H%M%S")}_MLOps_logger.log')
+os.makedirs(os.path.join(home, 'MLOPS_LOGS'), exist_ok=True)
+LOG_FILE: str = os.path.join(home, 'MLOPS_LOGS', f'{time.strftime("%Y%m%d-%H%M%S")}_MLOps_logger.log')
 
 
 def configure_logger():

--- a/tests/mlops/test_Experiment.py
+++ b/tests/mlops/test_Experiment.py
@@ -1,9 +1,9 @@
-from mlops.Experiment import Experiment
 import configparser
-from minio import Minio
 import os
+
 import docker
-import pytest
+
+from mlops.Experiment import Experiment
 
 
 class TestExperiment:
@@ -11,6 +11,10 @@ class TestExperiment:
     def setup(self):
         # currently only testing localhost code
         self.experiment = Experiment('test_entry.py', config_path='tests/data/test_config.cfg', project_path='tests/data')
+
+    def test_check_minio_credentials(self):
+        self.experiment.check_minio_credentials()
+        assert self.experiment.auth
 
     def test_check_dirty(self):
         """

--- a/tests/mlops/test_Experiment.py
+++ b/tests/mlops/test_Experiment.py
@@ -59,11 +59,11 @@ class TestExperiment:
         self.experiment.build_project_file()
         assert os.path.exists(os.path.join(self.experiment.project_path, 'MLproject'))
 
-    def test_build_experiment_image(self):
+    def build_experiment_image_subprocess(self):
         client = docker.from_env()
         images_1 = [img['RepoTags'][0] for img in client.api.images()]
         # assert self.experiment.experiment_name + ':latest' not in images_1
-        self.experiment.build_experiment_image()
+        self.experiment.build_experiment_image_subprocess()
         images_2 = [img['RepoTags'][0] for img in client.api.images()]
         assert self.experiment.experiment_name + ':latest' in images_2
 

--- a/tests/mlops/test_Experiment.py
+++ b/tests/mlops/test_Experiment.py
@@ -20,14 +20,6 @@ class TestExperiment:
         self.experiment = Experiment('test_entry.py', 'tests/data/test_config.cfg', project_path='.')
         assert not self.experiment.check_dirty()
 
-    def test_check_environment_variables(self):
-        test_var = os.environ['AWS_ACCESS_KEY_ID']
-        del os.environ['AWS_ACCESS_KEY_ID']
-        with pytest.raises(Exception) as e:
-            self.experiment.check_environment_variables()
-        # reset env var
-        os.environ['AWS_ACCESS_KEY_ID'] = test_var
-
     def test_config_setup(self):
         self.experiment.config_setup()
         assert self.experiment.experiment_name == 'test_project'
@@ -56,15 +48,6 @@ class TestExperiment:
         self.experiment.print_experiment_info()  # Call function.
         assert 'Name: test_project' in caplog.text
         assert 'Artifact Location: s3://mlflow' in caplog.text
-
-    def test_configure_minio(self):
-        # check mlflow bucket is created
-        self.experiment.configure_minio()
-        client = Minio(self.experiment.uri_formatted,
-                       self.experiment.minio_cred['user'],
-                       self.experiment.minio_cred['password'],
-                       secure=False)
-        assert 'mlflow' in (bucket.name for bucket in client.list_buckets())
 
     def test_build_project_file(self):
         if os.path.exists('MLproject'):


### PR DESCRIPTION
We have been using a very old version of minio that is incompatible with future releases, to avoid technical debt we should move to the new versions.

This PR makes the following changes:
- updates minio to RELEASE.2022-11-08T05-27-07Z which no longer uses the minio gateway. It also includes an updated UI which will make it easier to monitor file storage. In future we should look to distributing the artifact storage across minio instances. 
- uses mc container to create mlflow bucket. The credentials are still required but can be passed in any way supported by boto3. The recommended way to do this is to add a credentials file to ~/.aws/credentials which will be mounted to the docker container at runtime.
- replaces related tests

Since the new version of minio is not compatible with the old version we need to migrate the old files over to the new one. Our minio is so old that the migration process published by minio didn't work (https://blog.min.io/deprecation-of-the-minio-gateway/), I kept coming across errors when trying to import configs or export metadata. I have done a simple filesystem mirror locally though and that seems to have worked. Instructions below:

We need to start two instances of minio to mirror them. First we need to separate the existing data new data directory.
`mv <minio data dir> <new location>`

Then we need to recreate the old directory
`mkdir <minio data dir>`

 After this we can start the old minio using a simple docker run:
`docker run -p 9000:9000 --name minio_old -v <new location>:/data -e 'MINIO_ROOT_USER=minio' -e 'MINIO_ROOT_PASSWORD=qwer1234!' minio/minio:RELEASE.2021-03-17T02-33-02Z server /data`

Then we can start the new server
`docker compose up -d --build`

Then we need to set aliases using mc 
`mc alias set oldminio http://localhost:9000 USER PWD`
`mc alias set newminio http://localhost:8002 USER PWD`

Then we can start the migration:
`mc mirror --preserve oldminio/mlflow newminio/mlflow`