### PR TITLE
Allow options for image series in LoadImageXNATd.py

### DIFF
--- a/tests/data/requirements.txt
+++ b/tests/data/requirements.txt
@@ -1,4 +1,5 @@
 numpy
-torch==2.0.1
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==2.0.1+cpu
 mlflow
 boto3

--- a/tests/data/requirements.txt
+++ b/tests/data/requirements.txt
@@ -1,5 +1,4 @@
 numpy
--f https://download.pytorch.org/whl/torch_stable.html
-torch==2.0.1+cpu
+torch==2.0.1
 mlflow
 boto3

--- a/tests/mlflow_server/test_server.py
+++ b/tests/mlflow_server/test_server.py
@@ -3,7 +3,7 @@ from mlops.Experiment import Experiment
 
 class TestExperiment:
 
-    def setup(self):
+    def setup_method(self):
         # currently only testing localhost code
         self.experiment = Experiment('test_entry.py', config_path='tests/data/test_config.cfg', project_path='tests/data')
 

--- a/tests/mlops/data/transforms/test_LoadImageXNATd.py
+++ b/tests/mlops/data/transforms/test_LoadImageXNATd.py
@@ -14,7 +14,7 @@ from requests.auth import HTTPBasicAuth
 @pytest.mark.skip(reason="unable to test XNAT features on github actions currently. Not been able to create a connection to the test XNAT instance")
 class TestLoadImageXNATd:
 
-    def setup(self):
+    def setup_method(self):
         self.test_batch_size = 1
         self.xnat_configuration = {'server': 'http://localhost:80',
                                    'user': 'admin',

--- a/tests/mlops/release/test_Release.py
+++ b/tests/mlops/release/test_Release.py
@@ -9,7 +9,7 @@ release_config = 'tests/mlops/release/data/release_config_local.yml'
 
 class TestRelease:
 
-    def setup(self):
+    def setup_method(self):
         # currently only testing localhost code
         conf = parse_config(release_config)
         self.release = Release(conf)

--- a/tests/mlops/test_Experiment.py
+++ b/tests/mlops/test_Experiment.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class TestExperiment:
 
-    def setup(self):
+    def setup_method(self):
         # currently only testing localhost code
         self.experiment = Experiment('test_entry.py', config_path='tests/data/test_config.cfg',
                                      project_path='tests/data')

--- a/tests/mlops/test_cli.py
+++ b/tests/mlops/test_cli.py
@@ -4,7 +4,7 @@ from mlops.cli import run, release, parse_config
 
 class TestCLI:
 
-    def setup(self):
+    def setup_method(self):
         self.test_config = 'tests/mlops/release/data/release_config_local.yml'
 
     def test_run(self):


### PR DESCRIPTION
Allows options for functionality when encountering image series when loading from xnat:

Default = "error" -> raises error when encountering an image series of length greater than one

Options:

"keepfirst" -> keeps the first image in the series
"keeplast" -> keeps the last image in the series