### PR TITLE
Adds condition to retrieve Resource filenames from xnat_obj

### DIFF
--- a/mlops/data/tools/tools.py
+++ b/mlops/data/tools/tools.py
@@ -91,10 +91,17 @@ class DataBuilderXNAT:
 
                     elif type(xnat_obj) == list:
                         for obj in xnat_obj:
-                            action_data.append({'source_action': action.__name__,
-                                                'action_data': obj.uri,
-                                                'data_type': 'xnat_uri',
-                                                'data_label': data_label})
+                            if obj.cache_id[0] == 'ResourceCatalog':
+                                action_data.append({'source_action': action.__name__,
+                                                    'action_data': obj.uri,
+                                                    'data_type': 'xnat_uri',
+                                                    'data_label': data_label,
+                                                    'resource_files': list(obj.files)})  # retrieve filenames if xnat_obj contains Resource
+                            else:
+                                action_data.append({'source_action': action.__name__,
+                                                    'action_data': obj.uri,
+                                                    'data_type': 'xnat_uri',
+                                                    'data_label': data_label})
 
                     else:
                         action_data.append({'source_action': action.__name__,


### PR DESCRIPTION
The AutoSegCT pipeline requires extracting the filenames from the Resource objects within XNAT. This is not currently possible with the MLOps DataBuilderXNAT class.

This PR adds a simple condition whereby if the XNAT object under inspection contains an XNAT Resource object (identified by obj.cache_id = ResourceCatalog), then it collects the Resource object filenames and adds them to the action_data dictionary.

If a Resource object is not found, it proceeds with default DataBuilderXNAT behaviour.