### PR TITLE
Update dirty repo check to not include config files

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -103,4 +103,4 @@ jobs:
     - name: Stop containers
       if: always()
       run: |
-        docker-compose -f mlflow_server/docker-compose.yml down
+        docker compose -f mlflow_server/docker-compose.yml down

--- a/mlops/Experiment.py
+++ b/mlops/Experiment.py
@@ -91,12 +91,16 @@ class Experiment:
         local_commits_ahead_iter = head.commit.iter_items(repo, f'{tracking.path}..{head.path}')
         commits_ahead = sum(1 for _ in local_commits_ahead_iter)
 
-        if repo.is_dirty():
+        ignored_paths = ['config/local_config.cfg', 'config/config.cfg']
+        diffs = repo.index.diff(None)
+        is_dirty = any(d.a_path not in ignored_paths for d in diffs)
+
+        if is_dirty:
             raise Exception('Repository is dirty. Please commit your changes before running the experiment')
         if commits_ahead > 0:
             raise Exception('Local repository ahead of remote. Please push changes before running the experiment')
 
-        if not repo.is_dirty() and commits_ahead == 0:
+        if not is_dirty and commits_ahead == 0:
             return False
         else:
             raise Exception('Please synchronise local and remote code versions before running the experiment')

--- a/mlops/Experiment.py
+++ b/mlops/Experiment.py
@@ -91,9 +91,9 @@ class Experiment:
         local_commits_ahead_iter = head.commit.iter_items(repo, f'{tracking.path}..{head.path}')
         commits_ahead = sum(1 for _ in local_commits_ahead_iter)
 
-        ignored_paths = ['config/local_config.cfg', 'config/config.cfg']
+        ignored_dir = 'config/'
         diffs = repo.index.diff(None)
-        is_dirty = any(d.a_path not in ignored_paths for d in diffs)
+        is_dirty = any(not d.a_path.startswith(ignored_dir) for d in diffs)
 
         if is_dirty:
             raise Exception('Repository is dirty. Please commit your changes before running the experiment')


### PR DESCRIPTION
Currently always need to use --ignore_git_check as config files are always different to those on repo (due to passwords).

Now config files are ignored and this flag shouldn't be necessary.