### PR TITLE
Add --include_path option to include external folders in Docker build context

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -33,6 +33,10 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.ref }}
 
+    - name: Clear runner space
+      run: |
+        rm -rf /opt/hostedtoolcache
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -67,7 +71,7 @@ jobs:
       run: |
         mkdir -p ~/MLOps_data/mlflow_minio
         mkdir -p ~/MLOps_data/mlflow_db
-        docker compose -f mlflow_server/docker-compose.yml up -d --build
+        docker compose -f mlflow_server/docker-compose.yml up -d --build --wait
 
     - name: Setup flake8 annotations
       uses: rbialon/flake8-annotations@v1

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -64,10 +64,13 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: start MLOps server
+      # --wait blocks until all services are healthy or completed before returning.
+      # createbuckets depends on minio being healthy, so the mlflow bucket is guaranteed
+      # to exist before the test runs.    
       run: |
         mkdir -p ~/MLOps_data/mlflow_minio
         mkdir -p ~/MLOps_data/mlflow_db
-        docker compose -f mlflow_server/docker-compose.yml up -d --build
+        docker compose -f mlflow_server/docker-compose.yml up -d --build --wait
 
     - name: Setup flake8 annotations
       uses: rbialon/flake8-annotations@v1

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -64,13 +64,10 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: start MLOps server
-      # --wait blocks until all services are healthy or completed before returning.
-      # createbuckets depends on minio being healthy, so the mlflow bucket is guaranteed
-      # to exist before the test runs.    
       run: |
         mkdir -p ~/MLOps_data/mlflow_minio
         mkdir -p ~/MLOps_data/mlflow_db
-        docker compose -f mlflow_server/docker-compose.yml up -d --build --wait
+        docker compose -f mlflow_server/docker-compose.yml up -d --build
 
     - name: Setup flake8 annotations
       uses: rbialon/flake8-annotations@v1

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Wait for MLOps server to be ready
       # The createbuckets service has a race condition with MinIO startup - without a wait,
       # the test may start before the bucket is created, causing a NoSuchBucket error.
-      run: sleep 10
+      run: sleep 20
 
     - name: Test run CLI
       run: |

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -38,6 +38,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: debug Python version (before clear space)
+      run: |
+        which python
+        python --version
+        which pip
+        pip --version        
+
     - name: Clear runner space
       run: |
         rm -rf /opt/hostedtoolcache

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -54,6 +54,9 @@ jobs:
         mkdir -p ~/MLOps_data/mlflow_db
         docker compose -f mlflow_server/docker-compose.yml up -d --build
 
+    - name: Debug - generate logs to see why minio not working
+      run: docker compose -f mlflow_server/docker-compose.yml logs createbuckets
+
     - name: Test run CLI
       run: |
         cd tests/data

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -49,13 +49,13 @@ jobs:
         python -m pip install dist/*.whl
 
     - name: start MLOps server
+      # --wait blocks until all services are healthy or completed before returning.
+      # createbuckets depends on minio being healthy, so the mlflow bucket is guaranteed
+      # to exist before the test runs.
       run: |
         mkdir -p ~/MLOps_data/mlflow_minio
         mkdir -p ~/MLOps_data/mlflow_db
-        docker compose -f mlflow_server/docker-compose.yml up -d --build
-
-    - name: Debug - generate logs to see why minio not working
-      run: docker compose -f mlflow_server/docker-compose.yml logs createbuckets
+        docker compose -f mlflow_server/docker-compose.yml up -d --build --wait
 
     - name: Test run CLI
       run: |

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip build
         python -m build 
-        pip install dist/*.whl
+        python -m pip install dist/*.whl
 
     - name: start MLOps server
       run: |

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -34,7 +34,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -55,9 +55,9 @@ jobs:
         docker compose -f mlflow_server/docker-compose.yml up -d --build
 
     - name: Wait for MLOps server to be ready
-      # Docker Compose only waits for containers to start, not to be ready.
-      # Wait for createbuckets to finish (would mean ready).
-      run: docker compose -f mlflow_server/docker-compose.yml wait createbuckets
+      # Docker Compose only waits for containers to start, not be ready.
+      # `logs createbuckets` blocks until the createbuckets container exits and is healthy.
+      run: docker compose -f mlflow_server/docker-compose.yml logs createbuckets
 
     - name: Test run CLI
       run: |

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -42,6 +42,13 @@ jobs:
       run: |
         rm -rf /opt/hostedtoolcache
 
+    - name: debug Python version
+      run: |
+        which python
+        python --version
+        which pip
+        pip --version
+
     - name: Install csc-mlops
       run: |
         python -m pip install --upgrade pip build

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -49,15 +49,13 @@ jobs:
         python -m pip install dist/*.whl
 
     - name: start MLOps server
+      # --wait blocks until all services are healthy or completed before returning.
+      # createbuckets depends on minio being healthy, so the mlflow bucket is guaranteed
+      # to exist before the test runs.
       run: |
         mkdir -p ~/MLOps_data/mlflow_minio
         mkdir -p ~/MLOps_data/mlflow_db
-        docker compose -f mlflow_server/docker-compose.yml up -d --build
-
-    - name: Wait for MLOps server to be ready
-      # Docker Compose only waits for containers to start, not be ready.
-      # `logs createbuckets` blocks until the createbuckets container exits and is healthy.
-      run: docker compose -f mlflow_server/docker-compose.yml logs createbuckets
+        docker compose -f mlflow_server/docker-compose.yml up -d --build --wait
 
     - name: Test run CLI
       run: |

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -55,14 +55,9 @@ jobs:
         docker compose -f mlflow_server/docker-compose.yml up -d --build
 
     - name: Wait for MLOps server to be ready
-      # Docker Compose `depends_on` only waits for containers to start, not to be ready.
-      # We poll MinIO's health endpoint until it responds before running the test,
-      # otherwise createbuckets may fail to connect and the mlflow bucket is never created (NoSuchBucket error).
-      run: |
-        until curl -sf http://0.0.0.0:8002/minio/health/live; do
-          echo "Waiting for MinIO..."
-          sleep 2
-        done
+      # Docker Compose only waits for containers to start, not to be ready.
+      # Wait for createbuckets to finish (would mean ready).
+      run: docker compose -f mlflow_server/docker-compose.yml wait createbuckets
 
     - name: Test run CLI
       run: |

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -54,9 +54,6 @@ jobs:
         mkdir -p ~/MLOps_data/mlflow_db
         docker compose -f mlflow_server/docker-compose.yml up -d --build
 
-    - name: Debug - generate logs to see why minio not working
-      run: docker compose -f mlflow_server/docker-compose.yml logs createbuckets
-
     - name: Test run CLI
       run: |
         cd tests/data

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -55,9 +55,14 @@ jobs:
         docker compose -f mlflow_server/docker-compose.yml up -d --build
 
     - name: Wait for MLOps server to be ready
-      # The createbuckets service has a race condition with MinIO startup - without a wait,
-      # the test may start before the bucket is created, causing a NoSuchBucket error.
-      run: sleep 20
+      # Docker Compose `depends_on` only waits for containers to start, not to be ready.
+      # We poll MinIO's health endpoint until it responds before running the test,
+      # otherwise createbuckets may fail to connect and the mlflow bucket is never created (NoSuchBucket error).
+      run: |
+        until curl -sf http://0.0.0.0:8002/minio/health/live; do
+          echo "Waiting for MinIO..."
+          sleep 2
+        done
 
     - name: Test run CLI
       run: |

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -54,6 +54,9 @@ jobs:
         mkdir -p ~/MLOps_data/mlflow_db
         docker compose -f mlflow_server/docker-compose.yml up -d --build
 
+    - name: Debug createbuckets logs
+      run: docker compose -f mlflow_server/docker-compose.yml logs createbuckets
+
     - name: Test run CLI
       run: |
         cd tests/data

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -49,13 +49,13 @@ jobs:
         python -m pip install dist/*.whl
 
     - name: start MLOps server
-      # --wait blocks until all services are healthy or completed before returning.
-      # createbuckets depends on minio being healthy, so the mlflow bucket is guaranteed
-      # to exist before the test runs.
       run: |
         mkdir -p ~/MLOps_data/mlflow_minio
         mkdir -p ~/MLOps_data/mlflow_db
-        docker compose -f mlflow_server/docker-compose.yml up -d --build --wait
+        docker compose -f mlflow_server/docker-compose.yml up -d --build
+
+    - name: Debug - generate logs to see why minio not working
+      run: docker compose -f mlflow_server/docker-compose.yml logs createbuckets
 
     - name: Test run CLI
       run: |

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -54,8 +54,10 @@ jobs:
         mkdir -p ~/MLOps_data/mlflow_db
         docker compose -f mlflow_server/docker-compose.yml up -d --build
 
-    - name: Debug createbuckets logs
-      run: docker compose -f mlflow_server/docker-compose.yml logs createbuckets
+    - name: Wait for MLOps server to be ready
+      # The createbuckets service has a race condition with MinIO startup - without a wait,
+      # the test may start before the bucket is created, causing a NoSuchBucket error.
+      run: sleep 10
 
     - name: Test run CLI
       run: |

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -33,28 +33,14 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.ref }}
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: debug Python version (before clear space)
-      run: |
-        which python
-        python --version
-        which pip
-        pip --version        
-
     - name: Clear runner space
       run: |
         rm -rf /opt/hostedtoolcache
 
-    - name: debug Python version
-      run: |
-        which python
-        python --version
-        which pip
-        pip --version
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install csc-mlops
       run: |

--- a/mlflow_server/docker-compose.yml
+++ b/mlflow_server/docker-compose.yml
@@ -43,7 +43,7 @@ services:
               target: /data
 
     createbuckets:
-        image: minio/mc
+        image: minio/mc:RELEASE.2022-11-07T23-47-39Z
         depends_on:
             - minio
         environment:
@@ -54,7 +54,7 @@ services:
             /bin/sh -c "
             /usr/bin/mc alias set myminio http://minio:9000 ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY};
             /usr/bin/mc mb myminio/mlflow;
-            /usr/bin/mc policy set public myminio/mlflow;
+            /usr/bin/mc anonymous set public myminio/mlflow;
             exit 0;"
 
     db:

--- a/mlflow_server/docker-compose.yml
+++ b/mlflow_server/docker-compose.yml
@@ -45,7 +45,8 @@ services:
     createbuckets:
         image: minio/mc:RELEASE.2022-11-07T23-47-39Z
         depends_on:
-            - minio
+            minio:
+                condition: service_healthy
         environment:
             - NO_PROXY=minio,db,localhost
         networks:
@@ -81,8 +82,12 @@ services:
         image: mlflow_server
         container_name: mlflow_server
         depends_on:
-            - "minio"
-            - "db"
+            minio:
+                condition: service_healthy
+            db:
+                condition: service_started
+            createbuckets:
+                condition: service_completed_successfully
         networks:
             - frontend
             - backend

--- a/mlflow_server/docker-compose.yml
+++ b/mlflow_server/docker-compose.yml
@@ -82,8 +82,6 @@ services:
         image: mlflow_server
         container_name: mlflow_server
         depends_on:
-            minio:
-                condition: service_healthy
             db:
                 condition: service_started
             createbuckets:

--- a/mlflow_server/docker-compose.yml
+++ b/mlflow_server/docker-compose.yml
@@ -45,8 +45,7 @@ services:
     createbuckets:
         image: minio/mc:RELEASE.2022-11-07T23-47-39Z
         depends_on:
-            minio:
-                condition: service_healthy
+            - minio
         environment:
             - NO_PROXY=minio,db,localhost
         networks:
@@ -82,12 +81,8 @@ services:
         image: mlflow_server
         container_name: mlflow_server
         depends_on:
-            minio:
-                condition: service_healthy
-            db:
-                condition: service_started
-            createbuckets:
-                condition: service_completed_successfully
+            - "minio"
+            - "db"
         networks:
             - frontend
             - backend

--- a/mlops/Experiment.py
+++ b/mlops/Experiment.py
@@ -173,7 +173,6 @@ class Experiment:
             if os.path.exists(included_folder_dest):
                 raise FileExistsError(f"Destination folder already exists: {included_folder_dest}. Please remove it first or rename your source folder.")
 
-            shutil.rmtree(included_folder_dest, ignore_errors=True)
             shutil.copytree(self.include_path, included_folder_dest)
             logger.info(f'Copied {self.include_path} to {included_folder_dest}')
             atexit.register(shutil.rmtree, included_folder_dest, ignore_errors=True) # remove folder at exit            

--- a/mlops/Experiment.py
+++ b/mlops/Experiment.py
@@ -23,7 +23,8 @@ logger = logging.getLogger(__name__)
 class Experiment:
 
     def __init__(self, script, config_path, project_path: str = '.',
-                 verbose: bool = True, ignore_git_check: bool = False):
+                 verbose: bool = True, ignore_git_check: bool = False, 
+                 include_path: str = None):
         """
         The Experiment class is the interface through which all projects should be run.
         :param script: path to script to run
@@ -39,6 +40,7 @@ class Experiment:
         self.project_path = project_path
         self.verbose = verbose
         self.auth = None
+        self.include_path = include_path
 
         if 'pytest' in sys.modules:
             logger.warning('DEBUG ONLY - ignoring git checks due to test run detected')
@@ -56,6 +58,7 @@ class Experiment:
         self.env_setup()
         self.build_project_file()
         self.init_experiment()
+        self.include_path()
 
         if self.verbose:
             self.print_experiment_info()
@@ -154,6 +157,27 @@ class Experiment:
         # self.configure_minio()
         self.experiment_id = exp_id
 
+    def include_path(self):
+        """
+        Copies the folder at self.include_path to current context
+        :return:
+        """
+
+        if self.include_path:
+            folder_name = os.path.basename(os.path.abspath(self.include_path))
+            included_folder_dest = os.path.join(self.project_path, folder_name)
+
+            if not os.path.exists(self.include_path):
+                raise FileNotFoundError(f"Source folder does not exist: {self.include_path}")            
+            
+            if os.path.exists(included_folder_dest):
+                raise FileExistsError(f"Destination folder already exists: {included_folder_dest}. Please remove it first or rename your source folder.")
+
+            shutil.rmtree(included_folder_dest, ignore_errors=True)
+            shutil.copytree(self.include_path, included_folder_dest)
+            logger.info(f'Copied {self.include_path} to {included_folder_dest}')
+            atexit.register(shutil.rmtree, included_folder_dest, ignore_errors=True) # remove folder at exit            
+
     def print_experiment_info(self):
         """
         Prints basic experiment info to logger
@@ -249,15 +273,6 @@ class Experiment:
         """
         rebuild_docker = kwargs.get('rebuild_docker', False)
         shared_memory = kwargs.get('shared_memory', '8gb')
-        include_path = kwargs.get('include_path', None)
-
-        if include_path:
-            folder_name = os.path.basename(os.path.abspath(include_path))
-            included_folder_dest = os.path.join(self.project_path, folder_name)
-            shutil.rmtree(included_folder_dest, ignore_errors=True)
-            shutil.copytree(include_path, included_folder_dest)
-            logger.info(f'Copied {include_path} to {included_folder_dest}')
-            atexit.register(shutil.rmtree, included_folder_dest, ignore_errors=True) # remove folder at exit
 
         logger.info(f'Starting experiment: {self.experiment_name}')
 

--- a/mlops/Experiment.py
+++ b/mlops/Experiment.py
@@ -1,6 +1,8 @@
+import atexit
 import configparser
 import logging
 import os
+import shutil
 import subprocess
 import sys
 
@@ -247,6 +249,15 @@ class Experiment:
         """
         rebuild_docker = kwargs.get('rebuild_docker', False)
         shared_memory = kwargs.get('shared_memory', '8gb')
+        include_path = kwargs.get('include_path', None)
+
+        if include_path:
+            folder_name = os.path.basename(os.path.abspath(include_path))
+            included_folder_dest = os.path.join(self.project_path, folder_name)
+            shutil.rmtree(included_folder_dest, ignore_errors=True)
+            shutil.copytree(include_path, included_folder_dest)
+            logger.info(f'Copied {include_path} to {included_folder_dest}')
+            atexit.register(shutil.rmtree, included_folder_dest, ignore_errors=True) # remove folder at exit
 
         logger.info(f'Starting experiment: {self.experiment_name}')
 

--- a/mlops/Experiment.py
+++ b/mlops/Experiment.py
@@ -58,7 +58,7 @@ class Experiment:
         self.env_setup()
         self.build_project_file()
         self.init_experiment()
-        self.include_path()
+        self.add_path()
 
         if self.verbose:
             self.print_experiment_info()
@@ -157,7 +157,7 @@ class Experiment:
         # self.configure_minio()
         self.experiment_id = exp_id
 
-    def include_path(self):
+    def add_path(self):
         """
         Copies the folder at self.include_path to current context
         :return:

--- a/mlops/cli.py
+++ b/mlops/cli.py
@@ -58,15 +58,15 @@ def run(script, config_path, run_name, ignore_git_check, shared_memory, logging_
     # create Experiment
     exp = Experiment(script,
                      config_path=config_path,
-                     ignore_git_check=ignore_git_check
+                     ignore_git_check=ignore_git_check,
+                     include_path=include_path
                      )
 
     # run Experiment
     exp.run(docker_args={},
             run_name=run_name,
             rebuild_docker=rebuild_docker,
-            shared_memory=shared_memory,
-            include_path=include_path,
+            shared_memory=shared_memory
             )
 
 

--- a/mlops/cli.py
+++ b/mlops/cli.py
@@ -47,7 +47,8 @@ def cli(ctx):
               show_default=True, default=False)
 @click.option('--ignore_git_check', is_flag=True, show_default=True, default=False,
               help='TESTING ONLY - ignore git checks, occasionally it might be necessary to ignore the git checks for example, offline testing, do not use this feature if working on tracked models')
-def run(script, config_path, run_name, ignore_git_check, shared_memory, logging_level, rebuild_docker):
+@click.option('-i', '--include_path', 'include_path', help='Path to a folder to copy into the project directory before building the Docker image', default=None, type=click.Path(exists=True, file_okay=False))
+def run(script, config_path, run_name, ignore_git_check, shared_memory, logging_level, rebuild_docker, include_path):
     """
     Runs python project using csc-mlops framework.
 
@@ -65,6 +66,7 @@ def run(script, config_path, run_name, ignore_git_check, shared_memory, logging_
             run_name=run_name,
             rebuild_docker=rebuild_docker,
             shared_memory=shared_memory,
+            include_path=include_path,
             )
 
 

--- a/tests/data/requirements.txt
+++ b/tests/data/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==2.0.1+cpu
-mlflow
+mlflow==2.10.0
 boto3
 requests==2.31.0


### PR DESCRIPTION
Currently `mlops run()` builds a docker image from the local context i.e. assumes the docker file is located at `./Dockerfile` and the image will be created from `./`.

In some projects, there may be some shared utility folders outside of the context of mlops run() which may need to be included in the docker image. Rather than copy-pasting the necessary folders into the local context, you could now use `mlops run()` with the `-i` option to include a folder.

This PR also corrects some of the GitHub actions tests that have been failing for the past year or so on any PR made - see specific comments in the Files changed tab for more. 