### PR TITLE
fix: make git cleanliness check look at parent repos to avoid errors when mlops not run from repo root

### DIFF
--- a/mlops/Experiment.py
+++ b/mlops/Experiment.py
@@ -96,7 +96,7 @@ class Experiment:
         :return:
         """
         logger.debug('Comparing to remote git repository')
-        repo = Repo(self.project_path)
+        repo = Repo(self.project_path, search_parent_directories=True)
         head = repo.head.ref
         tracking = head.tracking_branch()
         local_commits_ahead_iter = head.commit.iter_items(repo, f'{tracking.path}..{head.path}')


### PR DESCRIPTION
Fix git check failing when using `mlops run` from a subdirectory. 

Issue:
`Repo(self.project_path)` only inspected exact path, so launching from a daughter directory raised `InvalidGitRepositoryError` even with a clean tree. 

Proposed fix:
Adding `search_parent_directories=True` argument checks whole repo for `.git`, regardless of the launch directory.

